### PR TITLE
feat: Add login and profile pages

### DIFF
--- a/pos/next.config.mjs
+++ b/pos/next.config.mjs
@@ -1,4 +1,29 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'http',
+        hostname: 'img1.kakaocdn.net',
+      },
+      {
+        protocol: 'http',
+        hostname: 't1.kakaocdn.net',
+      },
+      {
+        protocol: 'https',
+        hostname: 'img1.kakaocdn.net',
+      },
+      {
+        protocol: 'https',
+        hostname: 't1.kakaocdn.net',
+      },
+      {
+        protocol: 'https',
+        hostname: 'k.kakaocdn.net',
+      },
+    ],
+  },
+};
 
 export default nextConfig;

--- a/pos/src/app/login/page.js
+++ b/pos/src/app/login/page.js
@@ -1,0 +1,98 @@
+'use client';
+
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+
+export default function Login() {
+  const router = useRouter();
+
+  const handleKakaoLogin = () => {
+    const KAKAO_CLIENT_ID = process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID;
+    const REDIRECT_URI = `${window.location.origin}/oauth/kakao/callback`;
+    const SCOPE = encodeURIComponent('profile_nickname profile_image name birthday');
+    
+    const kakaoURL = `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_CLIENT_ID}&redirect_uri=${REDIRECT_URI}&response_type=code&scope=${SCOPE}`;
+    window.location.href = kakaoURL;
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gray-50">
+      <div className="max-w-md w-full space-y-8 p-8">
+        <div className="text-center">
+          <h2 className="mt-6 text-3xl font-bold text-gray-900">
+            로그인
+          </h2>
+          <p className="mt-2 text-sm text-gray-600">
+            간편하게 로그인하고 서비스를 이용해보세요
+          </p>
+        </div>
+
+        <div className="mt-8 space-y-4">
+          {/* 카카오 로그인 버튼 */}
+          <button
+            onClick={handleKakaoLogin}
+            className="w-full flex items-center justify-center px-4 py-3 border border-transparent text-base font-medium rounded-md text-[#391B1B] bg-[#FEE500] hover:bg-[#FEE500]/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#FEE500]"
+          >
+            <div className="flex items-center">
+              <Image
+                src="/kakao-logo.png"
+                alt="Kakao"
+                width={24}
+                height={24}
+                className="mr-2"
+              />
+              카카오로 시작하기
+            </div>
+          </button>
+
+          {/* 추가 로그인 버튼들을 위한 공간 */}
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <div className="w-full border-t border-gray-300" />
+            </div>
+            <div className="relative flex justify-center text-sm">
+              <span className="px-2 bg-gray-50 text-gray-500">
+                다른 로그인 방식
+              </span>
+            </div>
+          </div>
+
+          {/* 네이버 로그인 버튼 (비활성화) */}
+          <button
+            disabled
+            className="w-full flex items-center justify-center px-4 py-3 border border-transparent text-base font-medium rounded-md text-white bg-[#03C75A] opacity-50 cursor-not-allowed"
+          >
+            <div className="flex items-center">
+              준비중
+            </div>
+          </button>
+
+          {/* 구글 로그인 버튼 (비활성화) */}
+          <button
+            disabled
+            className="w-full flex items-center justify-center px-4 py-3 border border-gray-300 text-base font-medium rounded-md text-gray-700 bg-white opacity-50 cursor-not-allowed"
+          >
+            <div className="flex items-center">
+              준비중
+            </div>
+          </button>
+        </div>
+
+        {/* 추가 정보 */}
+        <div className="mt-8 text-center">
+          <p className="text-xs text-gray-500">
+            로그인함으로써 
+            <a href="#" className="font-medium text-indigo-600 hover:text-indigo-500 mx-1">
+              서비스 이용약관
+            </a>
+            및
+            <a href="#" className="font-medium text-indigo-600 hover:text-indigo-500 mx-1">
+              개인정보 처리방침
+            </a>
+            에 동의합니다
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+} 

--- a/pos/src/app/oauth/kakao/callback/page.js
+++ b/pos/src/app/oauth/kakao/callback/page.js
@@ -41,7 +41,7 @@ export default function KakaoCallback() {
       if (data.session) {
         // 세션 설정
         await supabase.auth.setSession(data.session);
-        router.push('/auth/test');
+        router.push('/profile');
       } else {
         throw new Error('세션 정보가 없습니다.');
       }

--- a/pos/src/app/profile/page.js
+++ b/pos/src/app/profile/page.js
@@ -1,0 +1,150 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+import Image from 'next/image';
+
+export default function Profile() {
+  const [user, setUser] = useState(null);
+  const [profile, setProfile] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const router = useRouter();
+  const supabase = createClientComponentClient();
+
+  useEffect(() => {
+    checkUser();
+  }, []);
+
+  const checkUser = async () => {
+    try {
+      const { data: { user }, error: userError } = await supabase.auth.getUser();
+      if (userError) throw userError;
+      
+      if (!user) {
+        router.push('/login');
+        return;
+      }
+
+      setUser(user);
+
+      const { data: profileData, error: profileError } = await supabase
+        .from('profiles')
+        .select('*')
+        .eq('id', user.id)
+        .single();
+
+      if (profileError) throw profileError;
+      setProfile(profileData);
+    } catch (error) {
+      console.error('프로필 조회 에러:', error);
+      alert('프로필을 불러오는데 실패했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleLogout = async () => {
+    try {
+      await supabase.auth.signOut();
+      router.push('/login');
+    } catch (error) {
+      console.error('로그아웃 에러:', error);
+      alert('로그아웃 중 오류가 발생했습니다.');
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-3xl mx-auto">
+        <div className="bg-white shadow rounded-lg overflow-hidden">
+          {/* 프로필 헤더 */}
+          <div className="bg-gradient-to-r from-purple-500 to-indigo-600 px-4 py-8">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center space-x-4">
+                {profile?.profile_image ? (
+                  <Image
+                    src={profile.profile_image}
+                    alt="Profile"
+                    width={80}
+                    height={80}
+                    className="rounded-full border-4 border-white"
+                  />
+                ) : (
+                  <div className="w-20 h-20 rounded-full bg-gray-200 flex items-center justify-center">
+                    <span className="text-2xl text-gray-500">
+                      {profile?.nickname?.[0]?.toUpperCase() || '?'}
+                    </span>
+                  </div>
+                )}
+                <div>
+                  <h2 className="text-2xl font-bold text-white">
+                    {profile?.nickname || '사용자'}
+                  </h2>
+                  <p className="text-indigo-100">{profile?.email}</p>
+                </div>
+              </div>
+              <button
+                onClick={handleLogout}
+                className="px-4 py-2 bg-white text-indigo-600 rounded-md hover:bg-indigo-50 transition-colors"
+              >
+                로그아웃
+              </button>
+            </div>
+          </div>
+
+          {/* 프로필 정보 */}
+          <div className="p-6 space-y-6">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <div className="space-y-2">
+                <p className="text-sm font-medium text-gray-500">이름</p>
+                <p className="text-base">{profile?.name || '미설정'}</p>
+              </div>
+              <div className="space-y-2">
+                <p className="text-sm font-medium text-gray-500">생일</p>
+                <p className="text-base">{profile?.birthday || '미설정'}</p>
+              </div>
+              <div className="space-y-2">
+                <p className="text-sm font-medium text-gray-500">가입 경로</p>
+                <p className="text-base capitalize">{profile?.provider || '일반'}</p>
+              </div>
+              <div className="space-y-2">
+                <p className="text-sm font-medium text-gray-500">계정 생성일</p>
+                <p className="text-base">
+                  {user?.created_at ? new Date(user.created_at).toLocaleDateString('ko-KR') : '알 수 없음'}
+                </p>
+              </div>
+            </div>
+
+            {/* 추가 정보 섹션 */}
+            <div className="mt-8 border-t pt-6">
+              <h3 className="text-lg font-medium text-gray-900 mb-4">계정 설정</h3>
+              <div className="space-y-4">
+                <button
+                  className="w-full px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200 transition-colors text-left"
+                  onClick={() => alert('준비 중인 기능입니다.')}
+                >
+                  프로필 수정
+                </button>
+                <button
+                  className="w-full px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200 transition-colors text-left"
+                  onClick={() => alert('준비 중인 기능입니다.')}
+                >
+                  알림 설정
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+} 


### PR DESCRIPTION
- Create login page with Kakao OAuth integration
- Implement profile page with user information display
- Add image domain configuration for Kakao CDN

Details:
- Add /login page with Kakao login button
- Create /profile page with user profile display
- Show profile image, name, email and other user details
- Add logout functionality
- Configure next.config.mjs for Kakao CDN image domains
- Update OAuth callback redirect to profile page

Technical changes:
- Add remotePatterns for Kakao CDN domains
- Implement profile data fetching from Supabase
- Add loading states and error handling
- Implement protected route logic